### PR TITLE
Installation - Grant write access to the pgrouting schema tables to a given PostgreSQL user group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+* Trigger a Lizmap event `lizmapPgroutingWktGeometryExported` containing the generated WKT
+  to allow JavaScript scripts for LWC <= 3.6 to use the generated route geometry.
+
+### Changed
+
+* Installation - Grant the write access on the schema `pgrouting` and its content to the
+  given group (use installation parameter `user_group`)
+
 ## 1.0.0 - 2023-06-09
 
 ### Added

--- a/pgrouting/install/configure.php
+++ b/pgrouting/install/configure.php
@@ -17,14 +17,22 @@ class pgroutingModuleConfigurator extends \Jelix\Installer\Module\Configurator
     {
         return array(
             'srid' => 2154,
+            'postgresql_user_group' => null,
         );
     }
 
     public function configure(ConfigurationHelpers $helpers)
     {
+        // srid = projection of the target pgrouting tables
         $this->parameters['srid'] = $helpers->cli()->askInformation(
             'SRID your are using?',
             $this->parameters['srid']
+        );
+
+        // user_group : to which group the write access should be granted on the schema pgrouting
+        $this->parameters['postgresql_user_group'] = $helpers->cli()->askInformation(
+            'PostgreSQL group of user to grant access on the schema pgrouting ?',
+            $this->parameters['postgresql_user_group']
         );
 
         $helpers->copyDirectoryContent('../www/css', jApp::wwwPath('assets/pgrouting/css'));

--- a/pgrouting/install/install.php
+++ b/pgrouting/install/install.php
@@ -42,5 +42,24 @@ class pgroutingModuleInstaller extends \Jelix\Installer\Module\Installer
         }
 
         $db->exec($sql);
+
+        // Grant right to the given PostgreSQL group of users
+        $sql_file = $this->getPath() . 'install/sql/grant.pgsql.sql';
+        $template = jFile::read($sql_file);
+        $tpl = new jTpl();
+        $group = $this->getParameter('postgresql_user_group');
+        jLog::log('APPLICATION DES DROITS ' . json_encode($group));
+        $tpl->assign('userGroup', $group);
+        if (!empty($group)) {
+            $sql = $tpl->fetchFromString($template, $group);
+            // Try to grant access
+            try {
+                $db->exec($sql);
+            } catch (Exception $e) {
+                jLog::log('An error occured while grant access on the pgrouting schema to the given group: ' . $group, 'error');
+
+                throw new jException('pgrouting~db.query.grant.bad');
+            }
+        }
     }
 }

--- a/pgrouting/install/install_1_6.php
+++ b/pgrouting/install/install_1_6.php
@@ -48,6 +48,24 @@ class pgroutingModuleInstaller extends jInstallerModule
             }
 
             $db->exec($sql);
+
+            // Grant right to the given PostgreSQL group of users
+            $sql_file = $this->path . 'install/sql/grant.pgsql.sql';
+            $template = jFile::read($sql_file);
+            $tpl = new jTpl();
+            $group = $this->getParameter('admin_group');
+            $tpl->assign('userGroup', $group);
+            if (!empty($group)) {
+                $sql = $tpl->fetchFromString($template, $group);
+                // Try to grant access
+                try {
+                    $db->exec($sql);
+                } catch (Exception $e) {
+                    jLog::log('An error occured while grant access on the pgrouting schema to the given group: ' . $group, 'error');
+
+                    throw new jException('pgrouting~db.query.grant.bad');
+                }
+            }
         }
     }
 }

--- a/pgrouting/install/sql/grant.pgsql.sql
+++ b/pgrouting/install/sql/grant.pgsql.sql
@@ -1,0 +1,5 @@
+-- Grant
+GRANT USAGE ON SCHEMA "pgrouting" TO "{$userGroup}";
+GRANT ALL ON ALL TABLES IN SCHEMA "pgrouting" TO "{$userGroup}";
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA "pgrouting" TO "{$userGroup}";
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA "pgrouting" TO "{$userGroup}";

--- a/pgrouting/locales/en_US/db.UTF-8.properties
+++ b/pgrouting/locales/en_US/db.UTF-8.properties
@@ -1,1 +1,2 @@
 query.ext.bad=Extension error, postgis or pgrouting is missing
+query.grant.bad=Grant access on the schema pgrouting to the given group failed

--- a/pgrouting/locales/fr_FR/db.UTF-8.properties
+++ b/pgrouting/locales/fr_FR/db.UTF-8.properties
@@ -1,1 +1,2 @@
 query.ext.bad=Erreur d'extension, il manque postgis ou pgrouting
+query.grant.bad=Erreur lors de la configuration des droits d'accès sur le schéma pgrouting

--- a/tests/lizmap/etc/conf/localconfig.d/localconfig.ini.php
+++ b/tests/lizmap/etc/conf/localconfig.d/localconfig.ini.php
@@ -1,6 +1,6 @@
 [modules]
 pgrouting.access=2
-pgrouting.installparam="srid=2154"
+pgrouting.installparam="srid=2154;postgresql_user_group=gis_group"
 
 [jResponseHtml]
 plugins = debugbar

--- a/tests/lizmap/initdb.d/init.sh
+++ b/tests/lizmap/initdb.d/init.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
 
+# Create user lizmap which will create and own the pgrouting database & schema
 psql --username postgres --no-password <<-EOSQL
     CREATE ROLE lizmap WITH LOGIN CREATEDB PASSWORD 'lizmap1234!';
     CREATE DATABASE lizmap WITH OWNER lizmap;
 EOSQL
 
+# Create extensions postgis & pgrouting
 psql --username postgres --no-password -d lizmap <<-EOSQL
     CREATE EXTENSION IF NOT EXISTS postgis SCHEMA public;
     CREATE EXTENSION IF NOT EXISTS pgrouting SCHEMA public;
+EOSQL
+
+# Create another test user and group which must be able to read & write
+# data inside the pgrouting schema
+psql --username postgres --no-password <<-EOSQL
+    CREATE ROLE "gis_user"  WITH LOGIN CREATEDB PASSWORD 'lizmap1234!';
+    CREATE ROLE "gis_group";
+    GRANT "gis_group" TO "gis_user";
+    GRANT CONNECT ON DATABASE "lizmap" TO "gis_user";
 EOSQL


### PR DESCRIPTION
If an installation parameter `postgresql_user_group` is configured before installing the module, for example in the `localconfig.ini.php` file, the PostgreSQL user which has created the `pgrouting` SQL strutcture (schemas and tables) in the database will also grant **write access** to this group.

This will allow the given group of users to manage data inside the two main tables `pgrouting.edges` & `pgrouting.nodes`
