### PR TITLE
Fix some typo and rename the dock title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+* Add a localized string for the dock title instead of `pgRouting`
+* Fix some typo
+
 ## 1.0.8 - 2023-07-11
 
 ### Fixed

--- a/pgrouting/classes/pgroutingDockable.listener.php
+++ b/pgrouting/classes/pgroutingDockable.listener.php
@@ -42,7 +42,7 @@ class pgroutingDockableListener extends jEventListener
                 $content = '<lizmap-pgrouting></lizmap-pgrouting>';
                 $dock = new lizmapMapDockItem(
                     'pgrouting',
-                    'pgRouting',
+                    \jLocale::get('pgrouting~dictionary.dock.title'),
                     $content,
                     99,
                     $bp . 'pgrouting/css/pgrouting.css',

--- a/pgrouting/install/PgRoutingDBInstallTrait.php
+++ b/pgrouting/install/PgRoutingDBInstallTrait.php
@@ -28,7 +28,7 @@ trait PgRoutingDBInstallTrait
                 try {
                     $db->exec($sql);
                 } catch (Exception $e) {
-                    jLog::log('An error occured while grant access on the pgrouting schema to the given group: ' . $group, 'error');
+                    jLog::log('An error occurred while grant access on the pgrouting schema to the given group: ' . $group, 'error');
 
                     throw new jException('pgrouting~db.query.grant.bad');
                 }

--- a/pgrouting/install/sql/install.pgsql.sql
+++ b/pgrouting/install/sql/install.pgsql.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS pgrouting.nodes(
     id serial primary key,
     geom geometry('POINT', 2154)
 );
-COMMENT ON TABLE pgrouting.nodes IS 'PgRouging graph nodes';
+COMMENT ON TABLE pgrouting.nodes IS 'PgRouting graph nodes';
 
 -- edges
 CREATE TABLE IF NOT EXISTS pgrouting.edges(
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS pgrouting.edges(
     source_data jsonb,
     geom geometry('LINESTRING', 2154)
 );
-COMMENT ON TABLE pgrouting.nodes IS 'PgRouging graph edges, with costs';
+COMMENT ON TABLE pgrouting.nodes IS 'PgRouting graph edges, with costs';
 
 -- routing optional POI
 CREATE TABLE IF NOT EXISTS pgrouting.routing_poi(

--- a/pgrouting/install/upgrade_1_0_8__1_0_9.php
+++ b/pgrouting/install/upgrade_1_0_8__1_0_9.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @author    3Liz
+ * @copyright 2023 3Liz
+ *
+ * @see       https://3liz.com
+ *
+ * @license   Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+require_once __DIR__ . '/PgRoutingDBInstallTrait.php';
+
+class pgroutingModuleUpgrader_1_0_8__1_0_9 extends jInstallerModule
+{
+    use PgRoutingDBInstallTrait;
+
+    public $targetVersions = array(
+        '1.0.9',
+    );
+    public $date = '2023-07-11';
+
+    public function install()
+    {
+        if ($this->firstDbExec()) {
+            $this->useDbProfile('pgrouting');
+            $db = $this->dbConnection();
+            $db->exec("COMMENT ON TABLE pgrouting.nodes IS 'PgRouting graph nodes'; COMMENT ON TABLE pgrouting.nodes IS 'PgRouting graph edges, with costs';");
+        }
+    }
+}

--- a/pgrouting/locales/en_US/dictionary.UTF-8.properties
+++ b/pgrouting/locales/en_US/dictionary.UTF-8.properties
@@ -1,3 +1,4 @@
+dock.title=Route
 draw.message=Draw origin and destination points.
 roadmap.title=Roadmap
 poi.title=Points of interest

--- a/pgrouting/locales/fr_FR/dictionary.UTF-8.properties
+++ b/pgrouting/locales/fr_FR/dictionary.UTF-8.properties
@@ -1,3 +1,4 @@
+dock.title=Itinéraire
 draw.message=Dessinez les points de départ et d'arrivée.
 roadmap.title=Parcours
 poi.title=Point sur le parcours

--- a/pgrouting/www/js/pgrouting.js
+++ b/pgrouting/www/js/pgrouting.js
@@ -128,7 +128,7 @@ class pgRouting extends HTMLElement {
         });
 
         // Refresh route only when user add a feature
-        // Not when we programmaticaly add a feature
+        // Not when we programmatically add a feature
         this._userAddFeature = true;
         milestoneSource.on('addfeature', event => {
             if (this._userAddFeature) {


### PR DESCRIPTION
Visiting https://demo.lizmap.com/lizmap/index.php/view/map?repository=modules&project=pgrouting

`pgRouting` is not the correct dock title for the end user, it should just be "Routing"/"Itinéraire"


I'm not sure how to test the migration ? Maybe we can skip for these 2 small typo